### PR TITLE
Ispravka split pravila

### DIFF
--- a/2019.2020/06.dpll.kodiranja/dpll.py
+++ b/2019.2020/06.dpll.kodiranja/dpll.py
@@ -154,7 +154,7 @@ def _DPLL(D, valuation):
 	newD = []
 	izabrani = razliciti_literali[0]
 	valuation[izabrani] = True
-	newD = zameni_literal(D, l, 'T')
+	newD = zameni_literal(D, izabrani, 'T')
 	print('SPLIT[{}-->T]'.format(izabrani))
 	print(newD)
 	res, val = _DPLL(newD, valuation)
@@ -163,7 +163,7 @@ def _DPLL(D, valuation):
 		return True, val
 
 	valuation[izabrani] = False
-	newD = zameni_literal(D, l, 'F')
+	newD = zameni_literal(D, izabrani, 'F')
 	print('SPLIT[{} --> F]'.format(izabrani))
 	res, val = _DPLL(newD, valuation)
 


### PR DESCRIPTION
U postojećoj implementaciji se u skupu D vrši zamena sa literalom "l" umesto "izabrani". Literal "l" zapravo predstavlja neki od elemenata prilikom iteriranja kroz D i kao takav ne mora biti onaj koji treba menjati.

Ukoliko se pokrene na primeru [[-4, 1], [4, -1], [-3, 2], [3, -2], [4, 3], [-3, -4]] dobija se da su sve promenljive True što nije tačno jer tada poslednja klauza nije zadovoljena.